### PR TITLE
Fixed typographical error, changed auxilliary to auxiliary in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ This function checks if `a` is a correct authenticator of a message `m` under th
 
 The `nacl.hash` function hashes a message `m`. It returns `a` hash `h`. The output length `#h` is always `nacl.hash_BYTES`.
 
-## Auxilliary functions
+## Auxiliary functions
 
 ### nacl.randombytes(l)
 


### PR DESCRIPTION
kext, I've corrected a typographical error in the documentation of the [lua-nacl](https://github.com/kext/lua-nacl) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
